### PR TITLE
support multiple schema in postgre import

### DIFF
--- a/sql-delta-import/src/main/scala/com/razorpay/spark/jdbc/ImportRunner.scala
+++ b/sql-delta-import/src/main/scala/com/razorpay/spark/jdbc/ImportRunner.scala
@@ -43,7 +43,8 @@ object ImportRunner extends App {
     config.partitionBy.toOption,
     config.database(),
     config.mapColumns.toOption,
-    config.maxExecTimeout()
+    config.maxExecTimeout(),
+    config.schema.toOption
   )
 
   JDBCImport(
@@ -67,6 +68,7 @@ class ImportRunnerConfig(arguments: Seq[String]) extends ScallopConf(arguments) 
   val partitionBy: ScallopOption[String] = opt[String](required = false)
   val mapColumns: ScallopOption[String] = opt[String](required = false)
   val maxExecTimeout: ScallopOption[Long] = opt[Long](default = Some(Constants.QUERY_TIMEOUT * 1000L))
+  val schema: ScallopOption[String] = opt[String](required = false)
 
   verify()
 }

--- a/sql-delta-import/src/main/scala/com/razorpay/spark/jdbc/JDBCImport.scala
+++ b/sql-delta-import/src/main/scala/com/razorpay/spark/jdbc/JDBCImport.scala
@@ -43,7 +43,8 @@ case class ImportConfig(
     partitionBy: Option[String],
     database: String,
     mapColumns: Option[String],
-    maxExecTimeout: Long
+    maxExecTimeout: Long,
+    schema: Option[String]
 ) {
 
   val splitColumn: String = splitBy.getOrElse(null.asInstanceOf[String])
@@ -128,8 +129,13 @@ class JDBCImport(
     val dbType = dbutils.secrets.get(scope = databricksScope, key = "DB_TYPE")
 
     val database = importConfig.database
+    val schema = importConfig.schema
 
-    val connectionUrl = s"jdbc:$dbType://$host:$port/$database"
+    var connectionUrl = s"jdbc:$dbType://$host:$port/$database"
+
+    if (dbType == Constants.POSTGRESQL && schema.isDefined){
+      connectionUrl = s"jdbc:$dbType://$host:$port/$database?currentSchema=${schema.get}"
+    }
 
     connectionUrl
   }

--- a/sql-delta-import/src/test/scala/com/razorpay/spark/jdbc/ImportTest.scala
+++ b/sql-delta-import/src/test/scala/com/razorpay/spark/jdbc/ImportTest.scala
@@ -90,7 +90,8 @@ class ImportTest extends AnyFunSuite with BeforeAndAfterAll {
         chunks = chunks,
         partitionBy = None,
         database = "test",
-        mapColumns = None
+        mapColumns = None,
+        schema = Some("public")
       )
     ).run()
 


### PR DESCRIPTION
Currenly by default the jdbc connection assumes that the public   schema should be used in case of postgresql.
but in entity automation case the schema could be different than public.
have added the support for that.