### PR TITLE
 on column data type casting resolve boolean to boolean

### DIFF
--- a/sql-delta-import/src/main/scala/com/razorpay/spark/jdbc/common/Constants.scala
+++ b/sql-delta-import/src/main/scala/com/razorpay/spark/jdbc/common/Constants.scala
@@ -18,7 +18,8 @@ object Constants {
   final val CREATED_AT = "created_at"
 
   final val COLUMN_DATATYPE_MAPPING = Map(
-    "bigint" -> "long"
+    "bigint" -> "long",
+    "boolean" -> "boolean"
   )
 
   final val STRING = "string"


### PR DESCRIPTION
https://razorpay.atlassian.net/browse/DE-3745
Sqoop on spark is not casting data types correctly.
for example in this run the columns type was passed as boolean but in the sink table it was stored as varchar.

https://razorpay-prod.cloud.databricks.com/?o=4745776473542049#job/43/run/9229482