### PR TITLE
Support for timestamp column while reading in parallel through databases

### DIFF
--- a/sql-delta-import/src/main/scala/com/razorpay/spark/jdbc/JDBCImport.scala
+++ b/sql-delta-import/src/main/scala/com/razorpay/spark/jdbc/JDBCImport.scala
@@ -150,7 +150,7 @@ class JDBCImport(
   private def readJDBCSourceInParallel(): DataFrame = {
 
     if (importConfig.splitBy.nonEmpty) {
-      val defaultString="defaultValue"
+      val defaultString=""
       val (lower, upper) = spark.read
         .jdbc(buildJdbcUrl, importConfig.boundsSql, jdbcParams)
         .selectExpr("cast(min as string) min", "cast(max as string) max")


### PR DESCRIPTION
**Problem -**
In Sqoop jobs whenever the partition column was of datatype timestamp, the code was producing error(cannot parse the bound value <some value> as timestamp)

**Source of problem-**
In spark.read.jdbc() we can pass lower and upper values as of type long only. The error was coming because the long epochs of timestamps cannot be used to compare with timestamp values on database while creating chunks.

**Solution-**
Replace spark.read.jdbc() with spark.read.format("jdbc") in which we can pass lower and upper values as string. The timestamps(lower and upper bounds) are typecasted to string instead of long(which was not possible in spark.read.jdbc() while it is possible in spark.read.format("jdbc)" ). This solves the problem as timestamps typecasted to string can be use for partitioning and creating chunks while parallel reading.

This works when partition column while reading is off type numeric, date or timestamp.